### PR TITLE
Bump hashicorp/azurerm

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.63.0"
+      version = "~>3.90.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
This pull request includes an update to the `providers.tf` file to ensure compatibility with the latest version of the AzureRM provider.

* [`providers.tf`](diffhunk://#diff-2bd310e796212f7e4b51f1dadcec884774f413369cfc039f82096d412727a19dL13-R13): Updated the `azurerm` provider version from `~>3.63.0` to `~>3.90.0` to ensure compatibility with the latest features and fixes.