### PR TITLE
Revert "ansible-core 2.17 以降は python3.7 以降が必要"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -118,7 +118,7 @@ resource "ansible_host" "web_server" {
   variables = {
     ansible_user                 = var.username
     ansible_ssh_private_key_file = "~/.ssh/id_rsa",
-    ansible_python_interpreter   = "/usr/bin/python3.9"
+    ansible_python_interpreter   = "/usr/bin/python3"
     ansible_become               = "yes"
     ansible_become_method        = "sudo"
   }


### PR DESCRIPTION
This pull request includes a small update to the `main.tf` file to ensure compatibility with different Python versions used by Ansible.

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL121-R121): Changed the `ansible_python_interpreter` variable from `"/usr/bin/python3.9"` to `"/usr/bin/python3"` to support a more generic Python 3 interpreter path.
* This reverts commit 59b88e81006bbae885bd98d5910a0b09b65b7749.