### PR TITLE
Add mysql

### DIFF
--- a/ansible/key.yml
+++ b/ansible/key.yml
@@ -1,3 +1,5 @@
 ---
 ## This file must be encrypted with the `ansible-vault encrypt` command.
 gh_token: '<GitHub personal access token>'
+ec_db_password: '<eccube_db_password>'
+stg_ec_db_password: '<stg_eccube_db_password>'

--- a/playbook.yml
+++ b/playbook.yml
@@ -161,6 +161,38 @@
         enabled: yes
         state: started
 
+    # - name: Create user with password
+    #   community.mysql.mysql_user:
+    #     state: present
+    #     name: eccube_db
+    #     password: "{{ ec_db_password }}"
+    #     host: "{{ item }}"
+    #     priv:
+    #       'eccube_db.*': 'ALL,GRANT'
+    #   with_items:
+    #     - '%'
+    #     - 'localhost'
+
+    # - name: Create staging user with password
+    #   community.mysql.mysql_user:
+    #     state: present
+    #     name: test_eccube_db
+    #     password: "{{ stg_ec_db_password }}"
+    #     host: "{{ item }}"
+    #     priv:
+    #       'test_eccube_db.*': 'ALL,GRANT'
+    #   with_items:
+    #     - '%'
+    #     - 'localhost'
+
+    # - name: Create a new database
+    #   community.mysql.mysql_db:
+    #     name: "{{ item }}"
+    #     state: present
+    #   with_items:
+    #     - eccube_db
+    #     - test_eccube_db
+
     - name: Update PHP settings
       lineinfile:
         path: /etc/php.ini


### PR DESCRIPTION
This pull request includes changes to the Ansible configuration files to add new database passwords and commented-out tasks for user and database creation.

### Additions to Configuration:

* [`ansible/key.yml`](diffhunk://#diff-8c66a01c65d94958fae9c26331baec15a5ec8b0169a3f445ade80e3c403bd114R4-R5): Added `ec_db_password` and `stg_ec_db_password` variables to store database passwords.

### Commented-Out Tasks for Future Implementation:

* [`playbook.yml`](diffhunk://#diff-6377f8a1937054624eac73b02854e7f99081cb731582fcecd1b435c5ded73120R164-R195): Added commented-out tasks for creating database users and databases for both production and staging environments.