### PR TITLE
パーミッション指定系は常に changed になるため ok の結果となるように変更

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -21,6 +21,7 @@
         - { regexp: '^ResourceDisk\.SwapSizeMB=.*$', line: 'ResourceDisk.SwapSizeMB=3072' }
 
     - name: remove gpg keys
+      changed_when: false
       rpm_key:
         key: 'https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux'
         state: absent
@@ -226,12 +227,14 @@
         job: certbot renew --post-hook "systemctl reload httpd"
 
     - name: Change permissions
+      changed_when: false
       file:
         path: /var/www/html
         owner: "{{ username }}"
         group: "{{ username }}"
 
     - name: Create hosting directories
+      changed_when: false
       file:
         path: "{{ item }}"
         state: directory
@@ -242,6 +245,7 @@
         - "/var/www/html/{{ staging }}.{{ fqdn }}"
 
     - name: Change permissions
+      changed_when: false
       file:
         path: "/var/www/html/{{ fqdn }}/{{ item.path }}"
         owner: "{{ item.owner }}"
@@ -258,6 +262,7 @@
       - { path: "./data/logs",  owner: "apache" }
 
     - name: Change permissions to staging
+      changed_when: false
       file:
         path: "/var/www/html/{{ staging }}.{{ fqdn }}/{{ item.path }}"
         owner: "{{ item.owner }}"


### PR DESCRIPTION
This pull request includes changes to the `playbook.yml` file to ensure that certain tasks do not trigger a changed state. The most important changes involve adding the `changed_when: false` condition to multiple tasks.

Changes to prevent unnecessary changed states:

* Added `changed_when: false` to the task for removing GPG keys.
* Added `changed_when: false` to the task for changing permissions of `/var/www/html`.
* Added `changed_when: false` to the task for creating hosting directories.
* Added `changed_when: false` to the task for changing permissions of specific paths within `/var/www/html/{{ fqdn }}`.
* Added `changed_when: false` to the task for changing permissions to staging directories.