### PR TITLE
公開鍵を ed25519 に変更

### DIFF
--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -1,5 +1,5 @@
-data "azurerm_ssh_public_key" "github" {
-  name                = "github"
+data "azurerm_ssh_public_key" "ed25519" {
+  name                = "ed25519"
   resource_group_name = var.pubkey_resource_group_name
 }
 resource "azurerm_linux_virtual_machine" "vm_web" {
@@ -11,7 +11,7 @@ resource "azurerm_linux_virtual_machine" "vm_web" {
   size                  = "Standard_B1ms"
   zone                  = "1"
   admin_ssh_key {
-    public_key = data.azurerm_ssh_public_key.github.public_key
+    public_key = data.azurerm_ssh_public_key.ed25519.public_key
     username   = var.username
   }
   boot_diagnostics {


### PR DESCRIPTION
This pull request includes changes to the `modules/vm/main.tf` file to update the SSH public key data source and its usage in the virtual machine resource configuration.

Key changes include:

* Updated the SSH public key data source from `github` to `ed25519` in the `data "azurerm_ssh_public_key"` block.
* Modified the `public_key` reference in the `admin_ssh_key` block of the `azurerm_linux_virtual_machine` resource to use the updated `ed25519` public key.