### PR TITLE
remove duplicate

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -105,12 +105,6 @@ output "sendgrid_link_branding_dns" {
   value = module.sendgrid.sendgrid_link_branding_dns
 }
 
-module "mackerel" {
-  source       = "./modules/mackerel"
-  external_url = "https://${var.fqdn}"
-  name         = var.fqdn
-}
-
 # ansible-galaxy collection install cloud.terraform
 resource "ansible_host" "web_server" {
   name   = "${var.username}.${var.location}.cloudapp.azure.com"


### PR DESCRIPTION
This pull request includes a change to the Terraform configuration file `main.tf` to remove the Mackerel module. This change simplifies the infrastructure setup by eliminating the Mackerel monitoring tool.

Changes to Terraform configuration:

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL108-L113): Removed the `mackerel` module, which included the source, external URL, and name parameters.