### PR TITLE
Fix private key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "ansible_host" "web_server" {
   groups = ["web"]
   variables = {
     ansible_user                 = var.username
-    ansible_ssh_private_key_file = "~/.ssh/id_rsa",
+    ansible_ssh_private_key_file = "~/.ssh/id_ed25519",
     ansible_python_interpreter   = "/usr/bin/python3"
     ansible_become               = "yes"
     ansible_become_method        = "sudo"


### PR DESCRIPTION
This pull request includes a small but significant change to the `main.tf` file. The change updates the SSH private key file used for the Ansible host configuration.

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL114-R114): Changed the `ansible_ssh_private_key_file` from `~/.ssh/id_rsa` to `~/.ssh/id_ed25519` in the `resource "ansible_host" "web_server"` block.