### PR TITLE
docs: add instructions for setting up WordPress auto-updates in READM…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,24 @@ terraform state pull > terraform.tfstate
 ansible-vault encrypt ansible/key.yml
 ansible-playbook -i inventory.yml playbook.yml --diff --ask-vault-pass
 ```
+
+### WordPress の自動更新を設定する
+
+```php
+// wp-config.php
+define('FS_METHOD', 'ssh2');
+define('FTP_BASE', '/path/to/wp/');
+define('FTP_CONTENT_DIR', '/path/to/wp/wp-content/');
+define('FTP_PLUGIN_DIR ', '/path/to/wp/wp-content/plugins/');
+define('FTP_PUBKEY', '/var/www/.ssh/id_rsa.pub');
+define('FTP_PRIKEY', '/var/www/.ssh/id_rsa');
+define('FTP_USER', '${adminUsername}');
+define('FTP_HOST', 'localhost');
+```
+
+#### WordPress を Git で管理している場合は以下を追加
+
+```php
+// wp-content/themes/themeName/functions.php
+add_filter( 'automatic_updates_is_vcs_checkout', '__return_false', 1 );
+```


### PR DESCRIPTION
This pull request includes a new section in the `README.md` file to guide users on setting up automatic updates for WordPress. The most important changes are:

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27-R47): Added instructions for configuring WordPress automatic updates using SSH and managing WordPress with Git.