### PR TITLE
Fix resource names

### DIFF
--- a/modules/zero_trust/main.tf
+++ b/modules/zero_trust/main.tf
@@ -1,4 +1,4 @@
-resource "cloudflare_zero_trust_application" "staging" {
+resource "cloudflare_zero_trust_access_application" "staging" {
   account_id                   = var.account_id
   allowed_idps                 = []
   app_launcher_visible         = true
@@ -18,7 +18,7 @@ resource "cloudflare_zero_trust_application" "staging" {
   type                         = "self_hosted"
 }
 
-resource "cloudflare_zero_trust_application" "admin" {
+resource "cloudflare_zero_trust_access_application" "admin" {
   account_id                = var.account_id
   allowed_idps              = []
   app_launcher_visible      = true
@@ -39,7 +39,7 @@ resource "cloudflare_zero_trust_application" "admin" {
   type                         = "self_hosted"
 }
 
-resource "cloudflare_zero_trust_application" "certbot_skip" {
+resource "cloudflare_zero_trust_access_application" "certbot_skip" {
   account_id                   = var.account_id
   allowed_idps                 = []
   app_launcher_visible         = true
@@ -63,7 +63,7 @@ resource "cloudflare_zero_trust_application" "certbot_skip" {
   }
 }
 
-resource "cloudflare_zero_trust_group" "allow_email_domain" {
+resource "cloudflare_zero_trust_access_group" "allow_email_domain" {
   account_id = var.account_id
   name       = "Allow domains"
 
@@ -74,7 +74,7 @@ resource "cloudflare_zero_trust_group" "allow_email_domain" {
   }
 }
 
-resource "cloudflare_zero_trust_group" "allow_ips_office" {
+resource "cloudflare_zero_trust_access_group" "allow_ips_office" {
   account_id = var.account_id
   name       = "office"
 
@@ -85,13 +85,13 @@ resource "cloudflare_zero_trust_group" "allow_ips_office" {
   }
 }
 
-data "cloudflare_zero_trust_identity_provider" "onetimepin" {
+data "cloudflare_zero_trust_access_identity_provider" "onetimepin" {
   name       = ""
   account_id = var.account_id
 }
 
-resource "cloudflare_zero_trust_policy" "staging_bypass_ips" {
-  application_id = cloudflare_zero_trust_application.staging.id
+resource "cloudflare_zero_trust_access_policy" "staging_bypass_ips" {
+  application_id = cloudflare_zero_trust_access_application.staging.id
   name           = "許可IP"
   precedence     = "1"
   decision       = "bypass"
@@ -99,13 +99,13 @@ resource "cloudflare_zero_trust_policy" "staging_bypass_ips" {
 
   include {
     group = [
-      cloudflare_zero_trust_group.allow_ips_office.id,
+      cloudflare_zero_trust_access_group.allow_ips_office.id,
     ]
   }
 }
 
-resource "cloudflare_zero_trust_policy" "staging_onetimepin" {
-  application_id = cloudflare_zero_trust_application.staging.id
+resource "cloudflare_zero_trust_access_policy" "staging_onetimepin" {
+  application_id = cloudflare_zero_trust_access_application.staging.id
   name           = "one-time pin"
   precedence     = "2"
   decision       = "allow"
@@ -113,18 +113,18 @@ resource "cloudflare_zero_trust_policy" "staging_onetimepin" {
 
   include {
     login_method = [
-      data.cloudflare_zero_trust_identity_provider.onetimepin.id,
+      data.cloudflare_zero_trust_access_identity_provider.onetimepin.id,
     ]
   }
   require {
     group = [
-      cloudflare_zero_trust_group.allow_email_domain.id,
+      cloudflare_zero_trust_access_group.allow_email_domain.id,
     ]
   }
 }
 
-resource "cloudflare_zero_trust_policy" "admin_bypass_ips" {
-  application_id = cloudflare_zero_trust_application.admin.id
+resource "cloudflare_zero_trust_access_policy" "admin_bypass_ips" {
+  application_id = cloudflare_zero_trust_access_application.admin.id
   name           = "office"
   precedence     = "1"
   decision       = "bypass"
@@ -132,13 +132,13 @@ resource "cloudflare_zero_trust_policy" "admin_bypass_ips" {
 
   include {
     group = [
-      cloudflare_zero_trust_group.allow_ips_office.id,
+      cloudflare_zero_trust_access_group.allow_ips_office.id,
     ]
   }
 }
 
-resource "cloudflare_zero_trust_policy" "admin_onetimepin" {
-  application_id = cloudflare_zero_trust_application.admin.id
+resource "cloudflare_zero_trust_access_policy" "admin_onetimepin" {
+  application_id = cloudflare_zero_trust_access_application.admin.id
   name           = "one-time pin"
   precedence     = "2"
   decision       = "allow"
@@ -146,19 +146,18 @@ resource "cloudflare_zero_trust_policy" "admin_onetimepin" {
 
   include {
     login_method = [
-      data.cloudflare_zero_trust_identity_provider.onetimepin.id,
+      data.cloudflare_zero_trust_access_identity_provider.onetimepin.id,
     ]
   }
   require {
     group = [
-      cloudflare_zero_trust_group.allow_email_domain.id,
+      cloudflare_zero_trust_access_group.allow_email_domain.id,
     ]
   }
 }
 
-resource "cloudflare_zero_trust_policy" "certbot_skip_bypass" {
-  application_id = cloudflare_zero_trust_application.certbot_skip.id
-  account_id     = var.account_id
+resource "cloudflare_zero_trust_access_policy" "certbot_skip_bypass" {
+  application_id = cloudflare_zero_trust_access_application.certbot_skip.id
   name           = "skip"
   precedence     = "1"
   decision       = "bypass"


### PR DESCRIPTION
This pull request updates the Terraform configuration for Cloudflare Zero Trust resources to use the newer `cloudflare_zero_trust_access_*` resource types. These changes align the configuration with the latest Cloudflare API and Terraform provider updates, ensuring compatibility and leveraging improved resource definitions.

### Resource Updates

* Updated all `cloudflare_zero_trust_application` resources to use `cloudflare_zero_trust_access_application` for `staging`, `admin`, and `certbot_skip` applications. [[1]](diffhunk://#diff-539d328a970c0daeaedee49f2e8338c9e12501ad7efd16c37956cb58ce103b38L1-R1) [[2]](diffhunk://#diff-539d328a970c0daeaedee49f2e8338c9e12501ad7efd16c37956cb58ce103b38L21-R21) [[3]](diffhunk://#diff-539d328a970c0daeaedee49f2e8338c9e12501ad7efd16c37956cb58ce103b38L42-R42)
* Updated all `cloudflare_zero_trust_group` resources to use `cloudflare_zero_trust_access_group` for `allow_email_domain` and `allow_ips_office` groups. [[1]](diffhunk://#diff-539d328a970c0daeaedee49f2e8338c9e12501ad7efd16c37956cb58ce103b38L66-R66) [[2]](diffhunk://#diff-539d328a970c0daeaedee49f2e8338c9e12501ad7efd16c37956cb58ce103b38L77-R77) [[3]](diffhunk://#diff-539d328a970c0daeaedee49f2e8338c9e12501ad7efd16c37956cb58ce103b38L88-R160)
* Updated `data "cloudflare_zero_trust_identity_provider"` to `data "cloudflare_zero_trust_access_identity_provider"` for the `onetimepin` identity provider.

### Policy Updates

* Updated all `cloudflare_zero_trust_policy` resources to use `cloudflare_zero_trust_access_policy` for policies such as `staging_bypass_ips`, `staging_onetimepin`, `admin_bypass_ips`, `admin_onetimepin`, and `certbot_skip_bypass`. This includes updating references to the new `cloudflare_zero_trust_access_*` resources. ([modules/zero_trust/main.tfL88-R160](diffhunk://#diff-539d328a970c0daeaedee49f2e8338c9e12501ad7efd16c37956cb58ce103b38L88-R160) and subsequent lines)