### PR TITLE
Terraform Cloud から Azure Storage Backend + GitHub Actions への移行

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,12 +1,18 @@
 name: Terraform
 
+# NOTE: このテンプレートリポジトリでは CI/CD は無効化されています
+# 新規プロジェクトで使用する際は、以下のコメントを解除してください
+#
+# on:
+#   push:
+#     branches:
+#       - main
+#   pull_request:
+#     branches:
+#       - main
+
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:  # 手動実行のみ有効
 
 permissions:
   id-token: write

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,136 @@
+name: Terraform
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  plan:
+    name: Terraform Plan
+    runs-on: ubuntu-latest
+    environment: production
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          # Common credentials (shared across projects)
+          AZURE_TENANT_ID: op://skirnir-workload-identity/azure-common-credentials/AZURE_TENANT_ID
+          AZURE_SUBSCRIPTION_ID: op://skirnir-workload-identity/azure-common-credentials/AZURE_SUBSCRIPTION_ID
+          # Project-specific credentials
+          # TODO: Replace <project> with your project name
+          AZURE_CLIENT_ID: op://<project>-infrastructure/azure-credentials/AZURE_CLIENT_ID
+          TF_VAR_cloudflare_api_token: op://<project>-infrastructure/terraform-secrets/cloudflare_api_token
+          TF_VAR_sendgrid_api_key: op://<project>-infrastructure/terraform-secrets/sendgrid_api_key
+          TF_VAR_mackerel_api_key: op://<project>-infrastructure/terraform-secrets/mackerel_api_key
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.7"
+          terraform_wrapper: false
+
+      - name: Setup tfcmt
+        uses: shirakiya/setup-tfcmt@v3
+
+      - name: Terraform Init
+        run: terraform init
+        env:
+          ARM_USE_OIDC: true
+          ARM_CLIENT_ID: ${{ env.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ env.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Terraform Format Check
+        run: terraform fmt -check
+
+      - name: Terraform Plan
+        run: tfcmt plan -patch -- terraform plan -no-color
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARM_USE_OIDC: true
+          ARM_CLIENT_ID: ${{ env.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ env.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+  apply:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+    environment: production
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          # Common credentials (shared across projects)
+          AZURE_TENANT_ID: op://skirnir-workload-identity/azure-common-credentials/AZURE_TENANT_ID
+          AZURE_SUBSCRIPTION_ID: op://skirnir-workload-identity/azure-common-credentials/AZURE_SUBSCRIPTION_ID
+          # Project-specific credentials
+          # TODO: Replace <project> with your project name
+          AZURE_CLIENT_ID: op://<project>-infrastructure/azure-credentials/AZURE_CLIENT_ID
+          TF_VAR_cloudflare_api_token: op://<project>-infrastructure/terraform-secrets/cloudflare_api_token
+          TF_VAR_sendgrid_api_key: op://<project>-infrastructure/terraform-secrets/sendgrid_api_key
+          TF_VAR_mackerel_api_key: op://<project>-infrastructure/terraform-secrets/mackerel_api_key
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.7"
+          terraform_wrapper: false
+
+      - name: Setup tfcmt
+        uses: shirakiya/setup-tfcmt@v3
+
+      - name: Terraform Init
+        run: terraform init
+        env:
+          ARM_USE_OIDC: true
+          ARM_CLIENT_ID: ${{ env.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ env.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Terraform Apply
+        run: tfcmt apply -- terraform apply -auto-approve
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARM_USE_OIDC: true
+          ARM_CLIENT_ID: ${{ env.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ env.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ env.AZURE_SUBSCRIPTION_ID }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,11 @@ AzureのVMベースのホスティングサービスをTerraformとAnsibleで構
 ### Terraform操作
 
 ```bash
-# Terraform Cloud経由でデプロイ
+# ローカル開発での実行（1Password CLI で secrets を取得）
+export TF_VAR_cloudflare_api_token=$(op read "op://<project>-infrastructure/terraform-secrets/cloudflare_api_token")
+export TF_VAR_sendgrid_api_key=$(op read "op://<project>-infrastructure/terraform-secrets/sendgrid_api_key")
+export TF_VAR_mackerel_api_key=$(op read "op://<project>-infrastructure/terraform-secrets/mackerel_api_key")
+
 terraform init
 terraform plan
 terraform apply
@@ -49,6 +53,7 @@ cf-terraforming generate --resource-type "cloudflare_record" >> imports.tf
 
 ### Terraformモジュール構成
 
+- **modules/github_actions/**: GitHub Actions OIDC認証、Terraform state用Storage Account
 - **modules/vm/**: Azure VMとその関連リソース（OS disk、SSH key）を作成
 - **modules/networks/**: VNet、サブネット、NSG、パブリックIPを管理
 - **modules/backup/**: Recovery Services VaultとVMバックアップポリシーを設定
@@ -73,22 +78,53 @@ playbook.ymlで以下の構成を行います：
 
 ### 重要な設定ファイル
 
-- **providers.tf**: Terraform Cloudとプロバイダーの設定
-- **variables.tf**: 変数定義（fqdn、username、location等）
+- **providers.tf**: Azure Storage BackendとProviderの設定
+- **variables.tf**: 変数定義（project_name、fqdn、username、location等）
 - **ansible/var_files.yml**: Ansible変数（プロジェクト固有の設定）
 - **ansible/key.yml**: 暗号化された秘密情報（DB パスワード等）
 - **inventory.yml**: Terraformの状態から動的にインベントリを生成
 
-## 新規プロジェクトセットアップ手順
+## Backend設定（Azure Storage）
 
-1. リポジトリをテンプレートから作成
-2. Terraform Cloudでworkspaceを作成
-3. 必要な認証情報を設定（Azure、Cloudflare、SendGrid等）
-4. providers.tfのworkspace名を更新
-5. variables.tfでプロジェクト固有の値を設定
-6. ansible/var_files.ymlを編集
-7. Terraformでインフラをデプロイ
-8. Ansibleでサーバーを構成
+### 認証方法
+
+**GitHub Actions (CI/CD)**:
+- Azure OIDC認証を使用（Service Principal）
+- 1Password Service Account で secrets 管理
+
+**ローカル開発**:
+- Azure CLI認証（`az login`）
+- 1Password CLI で secrets 取得
+
+### 1Password Vault 構成
+
+**共通 Vault（skirnir-workload-identity）**:
+- `azure-common-credentials`: AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID
+
+**プロジェクト専用 Vault（<project>-infrastructure）**:
+- `azure-credentials`: AZURE_CLIENT_ID
+- `terraform-secrets`: cloudflare_api_token, sendgrid_api_key, mackerel_api_key
+
+## 新規プロジェクトセットアップ
+
+詳細は [README.md](./README.md) を参照してください。
+
+### 概要
+
+1. テンプレートからリポジトリを作成
+2. Service Principal を手動作成（Bootstrap用）
+3. 1Password Vault、Service Account を作成
+4. GitHub Environment、Secret を設定
+5. variables.tf、providers.tf を更新
+6. Bootstrap実行（local backend → azurerm backend）
+7. PR作成、Plan/Apply検証
+
+### Bootstrap時のtargetリソース
+
+```bash
+terraform apply \
+  -target=module.github_actions
+```
 
 ## WordPress固有の設定
 
@@ -114,3 +150,24 @@ add_filter( 'automatic_updates_is_vcs_checkout', '__return_false', 1 );
 ## cf-terraforming によるインポートプロンプト
 
 - `@modules/cloudflare_dns/import-cf-terraforming.md` を参照してください
+
+## トラブルシューティング
+
+### よくある問題
+
+1. **Azure認証エラー**
+   - GitHub Actions: `OP_SERVICE_ACCOUNT_TOKEN`シークレットを確認
+   - ローカル: `az login`で再認証、または1Password CLIで認証情報を再取得
+
+2. **Backend初期化エラー**
+   - Storage Accountが存在することを確認
+   - Azure CLI認証が有効であることを確認
+   - Service Principalに`Storage Blob Data Contributor`権限があることを確認
+
+3. **1Password認証エラー**
+   - ローカル: `op signin`で再認証
+   - GitHub Actions: Service Accountトークンの有効期限を確認
+
+4. **GitHub Actions OIDC エラー**
+   - `ARM_USE_OIDC=true`が設定されていることを確認
+   - Federated Identity Credentialのsubjectが正しいことを確認

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ add_filter( 'automatic_updates_is_vcs_checkout', '__return_false', 1 );
 │   ├── azure_dns/         # Azure DNS
 │   ├── backup/            # Recovery Services Vault
 │   ├── cloudflare_dns/    # Cloudflare DNS
+│   ├── github_actions/    # GitHub Actions OIDC, Storage Account
 │   ├── insights/          # Application Insights
 │   ├── mackerel/          # Mackerel 監視
 │   ├── networks/          # VNet, Subnet, NSG
@@ -277,7 +278,6 @@ add_filter( 'automatic_updates_is_vcs_checkout', '__return_false', 1 );
 │   ├── vm/                # Virtual Machine
 │   ├── waf/               # Cloudflare WAF
 │   └── zero_trust/        # Cloudflare Zero Trust
-├── ci-cd.tf               # Service Principal, Storage Account
 ├── main.tf                # メインリソース定義
 ├── providers.tf           # Provider と Backend 設定
 ├── variables.tf           # 変数定義

--- a/README.md
+++ b/README.md
@@ -1,31 +1,241 @@
 # hosting-service-terraform-template
 
-## Usage
+AzureのVMベースのホスティングサービスをTerraformとAnsibleで構築するためのテンプレートリポジトリです。
 
-1. このリポジトリをテンプレートにして、リポジトリを新規作成
-   ```shell
-   gh repo create skirnir-dev/<projectname>-terraform --clone --private --template skirnir-dev/hosting-service-terraform-template
-   ```
-2. Terraform cloud に workspace を作成
-3. (MS Entra IDを使う場合) フェデレーション資格情報を作成
-    - `TFC_AZURE_RUN_CLIENT_ID` も設定する 
-4. (Cloudflareを使う場合) API キーを作成
-5. (Cloudflareを使う場合) Terraform cloud に Cloudflare の API キーを設定
-6. (SendGrid を使う場合) サブユーザーを作成
-7. [providers.tf](./providers.tf) 及び [ansible/var_files.yml](./ansible/var_files.yml) を設定
+## アーキテクチャ
 
+### インフラ構成
 
-### ansible
+```
+顧客プロジェクト
+├── Azure Resources
+│   ├── Resource Group: <fqdn>
+│   ├── Virtual Machine (Linux)
+│   ├── Virtual Network / Subnet / NSG
+│   ├── Public IP
+│   ├── Recovery Services Vault (Backup)
+│   └── Application Insights
+│
+├── Cloudflare
+│   ├── DNS Records
+│   ├── Zero Trust (Access)
+│   └── WAF Rules
+│
+├── SendGrid
+│   └── Subuser + Domain Authentication
+│
+└── Mackerel
+    └── External Monitoring
+```
 
-``` shell
-## terraform.tfstate ファイルを出力しておくと、 terraform ansible プラグインで inventory の情報を生成できる
+### CI/CD アーキテクチャ（完全独立構成）
+
+各プロジェクトが完全に独立した構成を持ちます:
+
+```
+<project>-terraform リポジトリ
+├── Azure Service Principal: <project>-terraform (独自)
+│   ├── Contributor (scope: Subscription)
+│   ├── User Access Administrator (scope: Resource Group)
+│   ├── Storage Blob Data Contributor (scope: Storage Account)
+│   └── Federated Credential: GitHub Actions
+│
+├── Azure Storage: state<project> (独自)
+│   └── Container: tfstate
+│
+├── 1Password Service Account: github-actions-<project> (独自)
+│   ├── skirnir-workload-identity Vault (読み取り)
+│   └── <project>-infrastructure Vault (読み取り)
+│
+└── 1Password Vaults:
+    ├── skirnir-workload-identity (共通)
+    │   ├── AZURE_TENANT_ID
+    │   └── AZURE_SUBSCRIPTION_ID
+    └── <project>-infrastructure (プロジェクト専用)
+        ├── AZURE_CLIENT_ID
+        ├── cloudflare_api_token
+        ├── sendgrid_api_key
+        └── mackerel_api_key
+```
+
+### 設計の利点
+
+1. **完全な独立性**: プロジェクト間の依存なし
+2. **Rate Limit 解決**: 各 SP は 1 つの Federated Credential のみ
+3. **セキュリティ**: 最小権限の原則、影響範囲の局所化
+4. **運用性**: プロジェクト削除時に全リソースをまとめて削除可能
+5. **スケーラビリティ**: 新規顧客への展開が容易
+
+## 新規顧客セットアップ手順
+
+### 前提条件
+
+- Azure CLI (`az`)
+- 1Password CLI (`op`)
+- GitHub CLI (`gh`)
+- Terraform CLI
+
+### Phase 0: リポジトリ作成
+
+```bash
+# テンプレートからリポジトリを作成
+gh repo create skirnir-dev/<project>-terraform --clone --private --template skirnir-dev/hosting-service-terraform-template
+cd <project>-terraform
+```
+
+### Phase 1: Service Principal 手動作成（Bootstrap）
+
+Storage Account 作成前に必要な Service Principal を手動で作成します。
+
+```bash
+# 1. Azure AD Application 作成
+az ad app create --display-name "<project>-terraform"
+APP_ID=$(az ad app list --display-name "<project>-terraform" --query "[0].appId" -o tsv)
+OBJECT_ID=$(az ad app list --display-name "<project>-terraform" --query "[0].id" -o tsv)
+
+# 2. Service Principal 作成
+az ad sp create --id $APP_ID
+SP_OBJECT_ID=$(az ad sp show --id $APP_ID --query "id" -o tsv)
+
+# 3. Federated Credential 追加（GitHub Actions用）
+az ad app federated-credential create \
+  --id $OBJECT_ID \
+  --parameters '{
+    "name": "<project>-github-actions",
+    "issuer": "https://token.actions.githubusercontent.com",
+    "subject": "repo:skirnir-dev/<project>-terraform:environment:production",
+    "audiences": ["api://AzureADTokenExchange"]
+  }'
+
+# 4. Subscription レベルで Contributor 権限付与
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+az role assignment create \
+  --assignee $SP_OBJECT_ID \
+  --role Contributor \
+  --scope /subscriptions/$SUBSCRIPTION_ID
+
+# 5. 値を記録
+echo "AZURE_CLIENT_ID: $APP_ID"
+echo "SP_OBJECT_ID: $SP_OBJECT_ID"
+```
+
+### Phase 2: 1Password Vault とアイテム作成
+
+```bash
+# 1. プロジェクト専用 Vault 作成
+op vault create <project>-infrastructure
+
+# 2. Azure認証情報アイテム作成
+op item create --category="API Credential" --title="azure-credentials" \
+  --vault="<project>-infrastructure" \
+  "AZURE_CLIENT_ID=$APP_ID"
+
+# 3. Terraform secrets アイテム作成
+op item create --category="API Credential" --title="terraform-secrets" \
+  --vault="<project>-infrastructure" \
+  "cloudflare_api_token=<token>" \
+  "sendgrid_api_key=<key>" \
+  "mackerel_api_key=<key>"
+
+# 4. 共通認証情報の確認（既存の skirnir-workload-identity Vault）
+op item get azure-common-credentials --vault=skirnir-workload-identity
+```
+
+### Phase 3: 1Password Service Account 作成
+
+```bash
+# プロジェクト専用の Service Account を作成
+op service-account create "github-actions-<project>" \
+  --vault "skirnir-workload-identity:read_items" \
+  --vault "<project>-infrastructure:read_items"
+
+# トークンを安全に保存（一度だけ表示される）
+```
+
+### Phase 4: GitHub Environment と Secret 設定
+
+```bash
+# Environment 作成
+gh api repos/skirnir-dev/<project>-terraform/environments/production --method PUT
+
+# Secret 設定
+gh secret set OP_SERVICE_ACCOUNT_TOKEN \
+  --repo skirnir-dev/<project>-terraform \
+  --env production
+# プロンプトで Service Account トークンを入力
+```
+
+### Phase 5: Terraform 設定
+
+```bash
+# 1. variables.tf のプロジェクト固有値を設定
+#    - project_name, fqdn, username など
+
+# 2. providers.tf の backend 設定を確認
+#    - storage_account_name, key などを確認
+
+# 3. ansible/var_files.yml を設定
+```
+
+### Phase 6: Bootstrap 実行（local backend → azurerm backend）
+
+```bash
+# 1. providers.tf の backend ブロックをコメントアウト
+
+# 2. local backend で初期化
+terraform init
+
+# 3. github_actions モジュールを作成（targeted apply）
+terraform apply -target=module.github_actions
+
+# 4. azure_client_id を 1Password に保存（必要に応じて）
+terraform output azure_client_id
+
+# 5. local state をバックアップ
+cp terraform.tfstate terraform.tfstate.local.backup
+
+# 6. providers.tf の backend ブロックをコメント解除
+#    storage_account_name は terraform output storage_account_name で確認
+
+# 7. azurerm backend に移行
+terraform init -migrate-state
+
+# 8. 残りのリソースを適用
+terraform apply
+```
+
+### Phase 7: 検証
+
+```bash
+# PR を作成して Plan job を確認
+git checkout -b test/initial-setup
+git add .
+git commit -m "feat: initial infrastructure setup"
+git push -u origin test/initial-setup
+gh pr create --title "Initial infrastructure setup" --body "Setup for <project>"
+
+# Plan job の成功を確認
+gh pr checks
+
+# マージして Apply job を確認
+gh pr merge --squash
+gh run list --limit 1
+```
+
+## Ansible でサーバー構成
+
+```bash
+# terraform.tfstate を取得（Ansible inventory で使用）
 terraform state pull > terraform.tfstate
-## ansible/key.yml を暗号化しておく
+
+# 秘密情報を暗号化
 ansible-vault encrypt ansible/key.yml
+
+# Playbook を実行
 ansible-playbook -i inventory.yml playbook.yml --diff --ask-vault-pass
 ```
 
-### WordPress の自動更新を設定する
+## WordPress の自動更新設定
 
 ```php
 // wp-config.php
@@ -39,9 +249,43 @@ define('FTP_USER', '${adminUsername}');
 define('FTP_HOST', 'localhost');
 ```
 
-#### WordPress を Git で管理している場合は以下を追加
+Git で管理している場合:
 
 ```php
 // wp-content/themes/themeName/functions.php
 add_filter( 'automatic_updates_is_vcs_checkout', '__return_false', 1 );
 ```
+
+## ディレクトリ構造
+
+```
+.
+├── .github/workflows/
+│   └── terraform.yml      # GitHub Actions ワークフロー
+├── ansible/
+│   ├── key.yml            # 暗号化された秘密情報
+│   ├── roles/             # Ansible ロール
+│   └── var_files.yml      # プロジェクト固有変数
+├── modules/
+│   ├── azure_dns/         # Azure DNS
+│   ├── backup/            # Recovery Services Vault
+│   ├── cloudflare_dns/    # Cloudflare DNS
+│   ├── insights/          # Application Insights
+│   ├── mackerel/          # Mackerel 監視
+│   ├── networks/          # VNet, Subnet, NSG
+│   ├── sendgrid/          # SendGrid
+│   ├── vm/                # Virtual Machine
+│   ├── waf/               # Cloudflare WAF
+│   └── zero_trust/        # Cloudflare Zero Trust
+├── ci-cd.tf               # Service Principal, Storage Account
+├── main.tf                # メインリソース定義
+├── providers.tf           # Provider と Backend 設定
+├── variables.tf           # 変数定義
+├── inventory.yml          # Ansible inventory
+└── playbook.yml           # Ansible playbook
+```
+
+## 関連ドキュメント
+
+- [CLAUDE.md](./CLAUDE.md) - Claude Code 向けガイダンス
+- [docs/migration-from-terraform-cloud.md](./docs/migration-from-terraform-cloud.md) - Terraform Cloud からの移行手順

--- a/docs/migration-from-terraform-cloud.md
+++ b/docs/migration-from-terraform-cloud.md
@@ -1,0 +1,422 @@
+# Terraform Cloud から Azure Storage Backend への移行手順
+
+既存の Terraform Cloud を使用しているプロジェクトを Azure Storage Backend + GitHub Actions に移行する手順です。
+
+## 前提条件
+
+- 既存の Terraform Cloud ワークスペースで管理されているプロジェクト
+- Azure CLI (`az`) がインストール済み
+- 1Password CLI (`op`) がインストール済み
+- GitHub CLI (`gh`) がインストール済み
+
+## 移行概要
+
+```
+移行フロー:
+1. Terraform Cloud → state backup
+2. Service Principal 手動作成
+3. 1Password 設定
+4. GitHub Environment 設定
+5. Terraform 設定更新
+6. local backend で初期化 + github_actions モジュール作成
+7. Azure Storage Backend へ移行
+8. GitHub Actions 検証
+9. Terraform Cloud 削除
+```
+
+## Phase 1: 事前準備
+
+### 1-1. Terraform Cloud から state をバックアップ
+
+```bash
+# 現在のディレクトリで実行
+terraform state pull > terraform.tfstate.tfcloud.backup
+```
+
+### 1-2. 現在のリソース数を確認
+
+```bash
+terraform state list | wc -l
+# 例: 89
+```
+
+## Phase 2: Service Principal 手動作成（Bootstrap）
+
+Storage Account を作成するために、先に Service Principal を手動で作成します。
+
+```bash
+# プロジェクト名を設定
+PROJECT_NAME="<project>"
+
+# 1. Azure AD Application 作成
+az ad app create --display-name "${PROJECT_NAME}-terraform"
+APP_ID=$(az ad app list --display-name "${PROJECT_NAME}-terraform" --query "[0].appId" -o tsv)
+OBJECT_ID=$(az ad app list --display-name "${PROJECT_NAME}-terraform" --query "[0].id" -o tsv)
+
+# 2. Service Principal 作成
+az ad sp create --id $APP_ID
+SP_OBJECT_ID=$(az ad sp show --id $APP_ID --query "id" -o tsv)
+
+# 3. Federated Credential 追加
+az ad app federated-credential create \
+  --id $OBJECT_ID \
+  --parameters "{
+    \"name\": \"${PROJECT_NAME}-github-actions\",
+    \"issuer\": \"https://token.actions.githubusercontent.com\",
+    \"subject\": \"repo:skirnir-dev/${PROJECT_NAME}-terraform:environment:production\",
+    \"audiences\": [\"api://AzureADTokenExchange\"]
+  }"
+
+# 4. Contributor 権限付与
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+az role assignment create \
+  --assignee $SP_OBJECT_ID \
+  --role Contributor \
+  --scope /subscriptions/$SUBSCRIPTION_ID
+
+# 5. 値を記録
+echo "=========================================="
+echo "AZURE_CLIENT_ID: $APP_ID"
+echo "APP_OBJECT_ID: $OBJECT_ID"
+echo "SP_OBJECT_ID: $SP_OBJECT_ID"
+echo "=========================================="
+```
+
+## Phase 3: 1Password 設定
+
+### 3-1. プロジェクト専用 Vault 作成
+
+```bash
+op vault create ${PROJECT_NAME}-infrastructure
+```
+
+### 3-2. Azure 認証情報アイテム作成
+
+```bash
+op item create --category="API Credential" --title="azure-credentials" \
+  --vault="${PROJECT_NAME}-infrastructure" \
+  "AZURE_CLIENT_ID=$APP_ID"
+```
+
+### 3-3. Terraform secrets アイテム作成
+
+既存の Terraform Cloud 変数から値を取得して設定:
+
+```bash
+# Terraform Cloud の変数を確認
+# Web UI: https://app.terraform.io/app/skirnir/<workspace>/variables
+
+op item create --category="API Credential" --title="terraform-secrets" \
+  --vault="${PROJECT_NAME}-infrastructure" \
+  "cloudflare_api_token=<既存の値>" \
+  "sendgrid_api_key=<既存の値>" \
+  "mackerel_api_key=<既存の値>"
+```
+
+### 3-4. Service Account 作成
+
+```bash
+op service-account create "github-actions-${PROJECT_NAME}" \
+  --vault "skirnir-workload-identity:read_items" \
+  --vault "${PROJECT_NAME}-infrastructure:read_items"
+
+# 表示されたトークンを安全に保存（一度だけ表示される）
+```
+
+## Phase 4: GitHub Environment 設定
+
+```bash
+# Environment 作成
+gh api repos/skirnir-dev/${PROJECT_NAME}-terraform/environments/production --method PUT
+
+# Secret 設定
+gh secret set OP_SERVICE_ACCOUNT_TOKEN \
+  --repo skirnir-dev/${PROJECT_NAME}-terraform \
+  --env production
+# プロンプトで Service Account トークンを入力
+```
+
+## Phase 5: Terraform 設定更新
+
+### 5-1. providers.tf の更新
+
+Terraform Cloud backend をコメントアウトし、Azure Storage backend を準備:
+
+```hcl
+terraform {
+  # Terraform Cloud (コメントアウト)
+  # cloud {
+  #   organization = "skirnir"
+  #   workspaces {
+  #     name = "<workspace>"
+  #   }
+  # }
+
+  # Azure Storage Backend (Bootstrap後にコメント解除)
+  # backend "azurerm" {
+  #   resource_group_name  = "<fqdn>"
+  #   storage_account_name = "state<project>"
+  #   container_name       = "tfstate"
+  #   key                  = "<project>-terraform.tfstate"
+  # }
+
+  required_version = ">=1.7"
+
+  required_providers {
+    # ... 既存のプロバイダー ...
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~>2.47"
+    }
+  }
+}
+
+provider "azuread" {}
+```
+
+### 5-2. variables.tf に project_name 追加
+
+```hcl
+variable "project_name" {
+  description = "Project name for CI/CD resources"
+  type        = string
+  default     = "<project>"
+}
+```
+
+### 5-3. main.tf に github_actions モジュール追加
+
+```hcl
+module "github_actions" {
+  source         = "./modules/github_actions"
+  project_name   = var.project_name
+  resource_group = azurerm_resource_group.rg
+}
+
+output "azure_client_id" {
+  value       = module.github_actions.azure_client_id
+  description = "Azure AD Application (Client) ID - Save to 1Password"
+  sensitive   = true
+}
+
+output "storage_account_name" {
+  value       = module.github_actions.storage_account_name
+  description = "Storage Account name for providers.tf backend configuration"
+}
+```
+
+### 5-4. modules/github_actions をコピー
+
+テンプレートから `modules/github_actions` ディレクトリをコピー:
+
+```bash
+cp -r ../hosting-service-terraform-template/modules/github_actions ./modules/
+```
+
+### 5-5. .github/workflows/terraform.yml をコピー
+
+```bash
+mkdir -p .github/workflows
+cp ../hosting-service-terraform-template/.github/workflows/terraform.yml .github/workflows/
+
+# <project> を実際のプロジェクト名に置換
+sed -i "s/<project>/${PROJECT_NAME}/g" .github/workflows/terraform.yml
+```
+
+## Phase 6: Bootstrap 実行
+
+### 6-1. Terraform Cloud state を復元
+
+```bash
+# Terraform Cloud backend をコメントアウトした状態で
+terraform init
+
+# バックアップした state を復元
+cp terraform.tfstate.tfcloud.backup terraform.tfstate
+```
+
+### 6-2. github_actions モジュールを作成
+
+```bash
+terraform apply -target=module.github_actions
+```
+
+### 6-3. Import ブロックを作成（Phase 2 で作成したリソース用）
+
+`imports.tf` を作成:
+
+```hcl
+import {
+  to = module.github_actions.azuread_application.terraform
+  id = "/applications/<APP_OBJECT_ID>"
+}
+
+import {
+  to = module.github_actions.azuread_service_principal.terraform
+  id = "<SP_OBJECT_ID>"
+}
+
+import {
+  to = module.github_actions.azuread_application_federated_identity_credential.github_actions
+  id = "<APP_ID>/federatedIdentityCredential/<CREDENTIAL_ID>"
+}
+
+import {
+  to = module.github_actions.azurerm_role_assignment.terraform_contributor
+  id = "/subscriptions/<SUBSCRIPTION_ID>/providers/Microsoft.Authorization/roleAssignments/<ROLE_ASSIGNMENT_ID>"
+}
+```
+
+> **Note**: ID の取得方法:
+> - APP_OBJECT_ID: `az ad app list --display-name "${PROJECT_NAME}-terraform" --query "[0].id" -o tsv`
+> - CREDENTIAL_ID: `az ad app federated-credential list --id $OBJECT_ID --query "[0].id" -o tsv`
+> - ROLE_ASSIGNMENT_ID: `az role assignment list --assignee $SP_OBJECT_ID --query "[?roleDefinitionName=='Contributor'].id" -o tsv`
+
+### 6-4. Plan でインポートを確認
+
+```bash
+terraform plan
+```
+
+### 6-5. Apply でインポート実行
+
+```bash
+terraform apply
+```
+
+### 6-6. local state をバックアップ
+
+```bash
+cp terraform.tfstate terraform.tfstate.local.backup
+```
+
+## Phase 7: Azure Storage Backend へ移行
+
+### 7-1. providers.tf の backend ブロックをコメント解除
+
+```hcl
+backend "azurerm" {
+  resource_group_name  = "<fqdn>"
+  storage_account_name = "state<project>"
+  container_name       = "tfstate"
+  key                  = "<project>-terraform.tfstate"
+}
+```
+
+### 7-2. Backend 移行
+
+```bash
+terraform init -migrate-state
+```
+
+確認メッセージに `yes` と入力。
+
+### 7-3. State 確認
+
+```bash
+terraform state list | wc -l
+# Phase 1 と同じ数 + github_actions モジュールのリソース数
+
+terraform plan
+# No changes が理想
+```
+
+## Phase 8: GitHub Actions 検証
+
+### 8-1. ブランチ作成とコミット
+
+```bash
+git checkout -b migrate/terraform-cloud-to-azure-storage
+git add .
+git commit -m "feat: migrate from Terraform Cloud to Azure Storage + GitHub Actions"
+git push -u origin migrate/terraform-cloud-to-azure-storage
+```
+
+### 8-2. PR 作成
+
+```bash
+gh pr create --title "Migrate to Azure Storage + GitHub Actions" --body "Resolves #<issue>"
+```
+
+### 8-3. Plan job 確認
+
+```bash
+gh pr checks
+```
+
+### 8-4. マージと Apply job 確認
+
+```bash
+gh pr merge --squash
+gh run list --limit 1
+```
+
+## Phase 9: クリーンアップ
+
+### 9-1. Terraform Cloud VCS 連携を削除
+
+Terraform Cloud Web UI で:
+1. ワークスペースの Settings → Version Control に移動
+2. "Disconnect from version control" をクリック
+
+### 9-2. Terraform Cloud ワークスペースを削除（オプション）
+
+Settings → Destruction and Deletion → Delete workspace
+
+### 9-3. imports.tf を移動
+
+```bash
+mv imports.tf imports.tf.completed
+```
+
+### 9-4. ローカルバックアップを整理
+
+```bash
+mkdir -p backups
+mv terraform.tfstate.*.backup backups/
+```
+
+## トラブルシューティング
+
+### Terraform Cloud からの直接移行不可
+
+`terraform init -migrate-state` が Terraform Cloud からは動作しない場合があります。
+
+**解決策**: `terraform state pull` でバックアップ → local backend で state を復元 → azurerm backend へ移行
+
+### Import ID 形式
+
+- Azure AD Application: `/applications/{object_id}` 形式が必要
+- Federated Credential: `{application_id}/federatedIdentityCredential/{credential_id}` 形式が必要
+
+### ARM_USE_OIDC エラー
+
+GitHub Actions で以下のエラーが出る場合:
+
+```
+Error: Error building ARM Config: Authenticating using the Azure CLI is only supported as a User
+```
+
+**解決策**: `terraform init` と `terraform plan/apply` に以下の環境変数を追加:
+
+```yaml
+env:
+  ARM_USE_OIDC: true
+  ARM_CLIENT_ID: ${{ env.AZURE_CLIENT_ID }}
+  ARM_TENANT_ID: ${{ env.AZURE_TENANT_ID }}
+  ARM_SUBSCRIPTION_ID: ${{ env.AZURE_SUBSCRIPTION_ID }}
+```
+
+### 1Password Service Account トークンエラー
+
+```
+error initializing client: Validation: (failed to session.DecodeSACredentials)
+```
+
+**解決策**: GitHub Environment Secret `OP_SERVICE_ACCOUNT_TOKEN` の値を再設定
+
+## 参考
+
+- [Azure Storage Backend Documentation](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm)
+- [GitHub Actions OIDC with Azure](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure)
+- [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/)

--- a/docs/migration-from-terraform-cloud.md
+++ b/docs/migration-from-terraform-cloud.md
@@ -220,7 +220,12 @@ mkdir -p .github/workflows
 cp ../hosting-service-terraform-template/.github/workflows/terraform.yml .github/workflows/
 
 # <project> を実際のプロジェクト名に置換
+# Linux の場合:
 sed -i "s/<project>/${PROJECT_NAME}/g" .github/workflows/terraform.yml
+# macOS の場合:
+# sed -i '' "s/<project>/${PROJECT_NAME}/g" .github/workflows/terraform.yml
+# または、両環境で動作する perl を使用:
+# perl -pi -e "s/<project>/${PROJECT_NAME}/g" .github/workflows/terraform.yml
 ```
 
 ## Phase 6: Bootstrap 実行
@@ -258,7 +263,7 @@ import {
 
 import {
   to = module.github_actions.azuread_application_federated_identity_credential.github_actions
-  id = "<APP_ID>/federatedIdentityCredential/<CREDENTIAL_ID>"
+  id = "<APP_OBJECT_ID>/federatedIdentityCredential/<CREDENTIAL_ID>"
 }
 
 import {

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,26 @@ resource "azurerm_resource_group" "rg" {
   location = var.location
   name     = var.fqdn
 }
+
+# =============================================================================
+# GitHub Actions CI/CD Infrastructure
+# =============================================================================
+module "github_actions" {
+  source         = "./modules/github_actions"
+  project_name   = var.project_name
+  resource_group = azurerm_resource_group.rg
+}
+
+output "azure_client_id" {
+  value       = module.github_actions.azure_client_id
+  description = "Azure AD Application (Client) ID - Save to 1Password"
+  sensitive   = true
+}
+
+output "storage_account_name" {
+  value       = module.github_actions.storage_account_name
+  description = "Storage Account name for providers.tf backend configuration"
+}
 module "virtual_machine" {
   source                     = "./modules/vm"
   resource_group             = azurerm_resource_group.rg

--- a/modules/github_actions/main.tf
+++ b/modules/github_actions/main.tf
@@ -23,7 +23,7 @@ resource "azuread_application" "terraform" {
 }
 
 resource "azuread_service_principal" "terraform" {
-  client_id = azuread_application.terraform.client_id
+  application_id = azuread_application.terraform.client_id
 }
 
 resource "azuread_application_federated_identity_credential" "github_actions" {

--- a/modules/github_actions/main.tf
+++ b/modules/github_actions/main.tf
@@ -1,0 +1,89 @@
+# =============================================================================
+# GitHub Actions Module
+# =============================================================================
+# This module creates resources for GitHub Actions OIDC authentication and
+# Terraform state management.
+#
+# Resources created:
+# - Azure AD Application and Service Principal
+# - Federated Identity Credential for GitHub Actions OIDC
+# - Storage Account and Container for Terraform state
+# - Role Assignments (Contributor, User Access Administrator, Storage Blob Data Contributor)
+# =============================================================================
+
+# Current Azure configuration
+data "azurerm_client_config" "current" {}
+
+# =============================================================================
+# Azure AD Application and Service Principal
+# =============================================================================
+
+resource "azuread_application" "terraform" {
+  display_name = "${var.project_name}-terraform"
+}
+
+resource "azuread_service_principal" "terraform" {
+  client_id = azuread_application.terraform.client_id
+}
+
+resource "azuread_application_federated_identity_credential" "github_actions" {
+  application_id = azuread_application.terraform.id
+  display_name   = "${var.project_name}-github-actions"
+  description    = "GitHub Actions OIDC for ${var.project_name}-terraform"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = "https://token.actions.githubusercontent.com"
+  subject        = "repo:${var.github_org}/${var.project_name}-terraform:environment:${var.github_environment}"
+}
+
+# =============================================================================
+# Storage Account for Terraform State
+# =============================================================================
+
+resource "azurerm_storage_account" "tfstate" {
+  name                     = "state${replace(var.project_name, "-", "")}"
+  resource_group_name      = var.resource_group.name
+  location                 = var.resource_group.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+
+  blob_properties {
+    versioning_enabled = true
+  }
+}
+
+resource "azurerm_storage_container" "tfstate" {
+  name                  = "tfstate"
+  storage_account_name  = azurerm_storage_account.tfstate.name
+  container_access_type = "private"
+}
+
+# =============================================================================
+# Role Assignments for Service Principal
+# =============================================================================
+
+# Contributor at Subscription level
+# Note: This is created manually in Phase 1 and imported into Terraform
+resource "azurerm_role_assignment" "terraform_contributor" {
+  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.terraform.object_id
+
+  lifecycle {
+    ignore_changes = [scope]
+  }
+}
+
+# User Access Administrator at Resource Group level
+resource "azurerm_role_assignment" "terraform_user_access_admin" {
+  scope                = var.resource_group.id
+  role_definition_name = "User Access Administrator"
+  principal_id         = azuread_service_principal.terraform.object_id
+}
+
+# Storage Blob Data Contributor at Storage Account level
+resource "azurerm_role_assignment" "terraform_storage" {
+  scope                = azurerm_storage_account.tfstate.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azuread_service_principal.terraform.object_id
+}

--- a/modules/github_actions/outputs.tf
+++ b/modules/github_actions/outputs.tf
@@ -1,0 +1,25 @@
+output "azure_client_id" {
+  value       = azuread_application.terraform.client_id
+  description = "Azure AD Application (Client) ID for GitHub Actions - Save this to 1Password"
+  sensitive   = true
+}
+
+output "storage_account_name" {
+  value       = azurerm_storage_account.tfstate.name
+  description = "Storage Account name for Terraform state"
+}
+
+output "storage_account_id" {
+  value       = azurerm_storage_account.tfstate.id
+  description = "Storage Account ID"
+}
+
+output "service_principal_object_id" {
+  value       = azuread_service_principal.terraform.object_id
+  description = "Service Principal Object ID"
+}
+
+output "application_id" {
+  value       = azuread_application.terraform.id
+  description = "Azure AD Application ID (Object ID)"
+}

--- a/modules/github_actions/required_providers.tf
+++ b/modules/github_actions/required_providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>3.90"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~>2.47"
+    }
+  }
+}

--- a/modules/github_actions/variables.tf
+++ b/modules/github_actions/variables.tf
@@ -1,0 +1,25 @@
+variable "project_name" {
+  description = "Project name used for naming resources (e.g., 'example' creates 'example-terraform' SP)"
+  type        = string
+}
+
+variable "resource_group" {
+  description = "Azure Resource Group where the Storage Account will be created"
+  type = object({
+    id       = string
+    name     = string
+    location = string
+  })
+}
+
+variable "github_org" {
+  description = "GitHub organization name"
+  type        = string
+  default     = "skirnir-dev"
+}
+
+variable "github_environment" {
+  description = "GitHub Actions environment name for OIDC subject"
+  type        = string
+  default     = "production"
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,24 +1,32 @@
 terraform {
-  cloud {
-    organization = "skirnir"
-    workspaces {
-      name = "hosting-service-terraform"
-    }
+  # Azure Storage Backend
+  # NOTE: Bootstrap時はこのブロックをコメントアウトして local backend で実行
+  # Storage Account 作成後にコメント解除して `terraform init -migrate-state` を実行
+  backend "azurerm" {
+    resource_group_name  = "<fqdn>"              # var.fqdn と同じ値
+    storage_account_name = "state<project>"      # var.project_name から生成
+    container_name       = "tfstate"
+    key                  = "<project>-terraform.tfstate"
   }
-  required_version = ">=0.12"
+
+  required_version = ">=1.7"
 
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.90.0"
+      version = "~>3.90"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~>2.47"
     }
     random = {
       source  = "hashicorp/random"
       version = "~>3.0"
     }
     ansible = {
-      version = "~> 1.3"
       source  = "ansible/ansible"
+      version = "~> 1.3"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
@@ -38,6 +46,7 @@ terraform {
 provider "azurerm" {
   features {}
 }
+provider "azuread" {}
 provider "cloudflare" {
   api_token = var.cloudflare_api_token
 }
@@ -46,5 +55,5 @@ provider "mackerel" {
 }
 provider "sendgrid" {
   api_key = var.sendgrid_api_key
-  subuser = "<subuser>"
+  subuser = var.username
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "project_name" {
+  description = "Project name for CI/CD resources (e.g., 'example' creates 'example-terraform' SP, 'stateexample' Storage Account)"
+  type        = string
+  default     = "example"
+}
 variable "fqdn" {
   default = "example.com"
   type    = string


### PR DESCRIPTION
## 概要

Terraform Cloud から Azure Storage Backend + GitHub Actions への移行をサポートするテンプレート更新です。

skirnir.co.jp-terraform での移行実績（PR #40）をフィードバックしています。

## 変更内容

### 新規追加

- **modules/github_actions/**: GitHub Actions OIDC 認証モジュール
  - Azure AD Application と Service Principal
  - Federated Identity Credential
  - Storage Account と Container
  - Role Assignments

- **.github/workflows/terraform.yml**: Plan/Apply ワークフロー
  - Azure OIDC 認証
  - 1Password Service Account によるシークレット管理
  - tfcmt による PR コメント

- **docs/migration-from-terraform-cloud.md**: 移行ガイド

### 更新

- **providers.tf**: Azure Storage Backend + azuread provider
- **main.tf**: github_actions モジュール呼び出し
- **variables.tf**: project_name 変数追加
- **README.md**: 新規顧客導入手順とアーキテクチャ説明
- **CLAUDE.md**: Azure Storage Backend 設定ドキュメント

## アーキテクチャ

各プロジェクトが完全に独立した構成を持ちます：

- 独自の Service Principal
- 独自の Storage Account
- 独自の 1Password Service Account

## 使い方

- **新規顧客**: README.md の手順に従う
- **既存顧客（Terraform Cloud からの移行）**: docs/migration-from-terraform-cloud.md の手順に従う

## 参考

- skirnir-dev/skirnir.co.jp-terraform#40
- skirnir-dev/skirnir.co.jp-terraform#39

🤖 Generated with [Claude Code](https://claude.com/claude-code)